### PR TITLE
Make even smaller circles

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,7 +46,7 @@ const App = () => {
   if (maps) {
     const random = seedrandom(todaysIndex + "circles");
     let newRadius = 60000
-    while (newRadius > 50) {
+    while (newRadius >= 25) {
       const previousCircle = circles[circles.length - 1];
       /* Find random point in circle with radius away from real answer. That point is now the circle's new midpoint. */
       newRadius = Math.pow(previousCircle.radius, 0.95);


### PR DESCRIPTION
There is currently an edge case where you can be inside of the very smallest circle while still being more than 50m away (because we stop making circles when the _radius_ reaches 50m, rather than the _diameter_ and we fall back to the smallest possible circle if there isn't one that you are outside of).

<pre align="center"><img width=350" alt src="https://user-images.githubusercontent.com/5347151/199003560-b82408b8-8784-465b-a88d-0de7802360af.png" /></pre>

This makes even smaller circles so that it is actually impossible to be inside of the smallest circle without having already won